### PR TITLE
Add recording-persistence event metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ Note: `ZM_USER` and `ZM_PASSWORD` are only needed if your ZoneMinder instance ha
 * `ZM_USER` (*optional*) - ZoneMinder username for authentication. Required if ZoneMinder has `OPT_USE_AUTH` enabled. Must be provided together with `ZM_PASSWORD`.
 * `ZM_PASSWORD` (*optional*) - ZoneMinder password for authentication. Required if ZoneMinder has `OPT_USE_AUTH` enabled. Must be provided together with `ZM_USER`.
 * `ZMES_WEBSOCKET_URL` (*optional*) - ZMES Websocket URL, if you also want to test connectivity to that
+* `ZM_EVENT_WINDOW_SECONDS` (*optional*, default `900`) - Rolling window, in seconds, over which the `zm_monitor_recent_*` event metrics are aggregated (see [Recording-persistence metrics](#recording-persistence-metrics)).
+* `ZM_EVENT_GRACE_SECONDS` (*optional*, default `120`) - Events that ended more recently than this are excluded from the windowed aggregates, because ZoneMinder may not have finished computing their `DiskSpace` yet; without this grace period a just-ended healthy event would momentarily read as zero-size.
+* `ZM_EVENT_QUERY_LIMIT` (*optional*, default `500`) - Maximum number of events fetched per scrape. Keep this comfortably above the number of events your busiest camera set produces within the query window (`ZM_EVENT_WINDOW_SECONDS` + 15 min); pyzm sorts newest-first and stops at this limit, so too low a value silently truncates the window and can drop quiet monitors entirely.
+
+### Recording-persistence metrics
+
+Every `zm_monitor_*` metric other than these proves that *capture* is alive (the daemon is running, grabbing frames into the shared-memory buffer). None of them prove that events actually reached *disk* -- a failure where capture keeps working but writes fail (e.g. a detached/unwritable storage volume) leaves every capture metric green while nothing is recorded.
+
+These metrics close that gap by inspecting recently-*ended* events:
+
+* `zm_monitor_last_event_disk_space_bytes` - DiskSpace of the newest ended event. Combined with the age metric below, this is the core signal: *the most recent finished recording saved N bytes.*
+* `zm_monitor_last_event_end_time_age_seconds` - seconds since that event ended (a freshness gate; a camera producing no events simply has no series).
+* `zm_monitor_last_event_frames` - frame count of the newest ended event.
+* `zm_monitor_last_event_id` - ID of the newest ended event. Event IDs are monotonic, so this is safe to use with `increase()` as an event-creation rate.
+* `zm_monitor_recent_ended_event_count` - events that ended in the window (denominator for a zero-size ratio).
+* `zm_monitor_recent_ended_zero_size_event_count` - events that ended in the window having saved zero bytes to disk.
+* `zm_monitor_recent_event_disk_space_bytes` - sum of DiskSpace over events that ended in the window (recording throughput).
+* `zm_monitor_recent_min_event_disk_space_bytes` / `zm_monitor_recent_min_event_frames` - smallest event size / frame count in the window, to surface partial or truncated writes that a `== 0` check would miss.
+
+The windowed aggregates exclude still-open events and purged events (`Emptied=1`, whose files are legitimately gone). **The `recent_*` metrics are sliding-window gauges computed at scrape time -- read them directly; do not apply `rate()`/`increase()`, which would double-count across overlapping windows.** Only `zm_monitor_last_event_id` is a monotonic value suitable for `increase()`.
 
 ## Grafana Dashboard
 
@@ -356,6 +376,78 @@ zm_monitor_zone_count{id="3",name="DiningRoom"} 1.0
 zm_monitor_zone_count{id="4",name="LivingRoom"} 1.0
 zm_monitor_zone_count{id="5",name="BasementDoorRm"} 1.0
 zm_monitor_zone_count{id="6",name="Cats"} 1.0
+# HELP zm_monitor_last_event_disk_space_bytes DiskSpace in bytes of the most recent ended event for this monitor
+# TYPE zm_monitor_last_event_disk_space_bytes gauge
+zm_monitor_last_event_disk_space_bytes{id="1",name="FrontPorch"} 3.87e+06
+zm_monitor_last_event_disk_space_bytes{id="2",name="Office"} 2.14e+06
+zm_monitor_last_event_disk_space_bytes{id="3",name="DiningRoom"} 5.02e+06
+zm_monitor_last_event_disk_space_bytes{id="4",name="LivingRoom"} 1.63e+06
+zm_monitor_last_event_disk_space_bytes{id="5",name="BasementDoorRm"} 4.41e+06
+zm_monitor_last_event_disk_space_bytes{id="6",name="Cats"} 2.29e+06
+# HELP zm_monitor_last_event_end_time_age_seconds Seconds since the most recent ended event for this monitor ended
+# TYPE zm_monitor_last_event_end_time_age_seconds gauge
+zm_monitor_last_event_end_time_age_seconds{id="1",name="FrontPorch"} 42.0
+zm_monitor_last_event_end_time_age_seconds{id="2",name="Office"} 315.0
+zm_monitor_last_event_end_time_age_seconds{id="3",name="DiningRoom"} 12.0
+zm_monitor_last_event_end_time_age_seconds{id="4",name="LivingRoom"} 588.0
+zm_monitor_last_event_end_time_age_seconds{id="5",name="BasementDoorRm"} 7.0
+zm_monitor_last_event_end_time_age_seconds{id="6",name="Cats"} 133.0
+# HELP zm_monitor_last_event_frames Frame count of the most recent ended event for this monitor
+# TYPE zm_monitor_last_event_frames gauge
+zm_monitor_last_event_frames{id="1",name="FrontPorch"} 152.0
+zm_monitor_last_event_frames{id="2",name="Office"} 101.0
+zm_monitor_last_event_frames{id="3",name="DiningRoom"} 151.0
+zm_monitor_last_event_frames{id="4",name="LivingRoom"} 102.0
+zm_monitor_last_event_frames{id="5",name="BasementDoorRm"} 300.0
+zm_monitor_last_event_frames{id="6",name="Cats"} 88.0
+# HELP zm_monitor_last_event_id Event ID of the most recent ended event for this monitor (monotonic; safe to use with increase() as an event-creation rate)
+# TYPE zm_monitor_last_event_id gauge
+zm_monitor_last_event_id{id="1",name="FrontPorch"} 68302.0
+zm_monitor_last_event_id{id="2",name="Office"} 68291.0
+zm_monitor_last_event_id{id="3",name="DiningRoom"} 68305.0
+zm_monitor_last_event_id{id="4",name="LivingRoom"} 68230.0
+zm_monitor_last_event_id{id="5",name="BasementDoorRm"} 68306.0
+zm_monitor_last_event_id{id="6",name="Cats"} 68299.0
+# HELP zm_monitor_recent_ended_event_count Count of events that ended in the last 900s (excludes still-open and purged events; windowed gauge, do not rate())
+# TYPE zm_monitor_recent_ended_event_count gauge
+zm_monitor_recent_ended_event_count{id="1",name="FrontPorch"} 3.0
+zm_monitor_recent_ended_event_count{id="2",name="Office"} 1.0
+zm_monitor_recent_ended_event_count{id="3",name="DiningRoom"} 5.0
+zm_monitor_recent_ended_event_count{id="4",name="LivingRoom"} 2.0
+zm_monitor_recent_ended_event_count{id="5",name="BasementDoorRm"} 8.0
+zm_monitor_recent_ended_event_count{id="6",name="Cats"} 2.0
+# HELP zm_monitor_recent_ended_zero_size_event_count Count of events that ended in the last 900s having saved zero bytes to disk (windowed gauge, do not rate())
+# TYPE zm_monitor_recent_ended_zero_size_event_count gauge
+zm_monitor_recent_ended_zero_size_event_count{id="1",name="FrontPorch"} 0.0
+zm_monitor_recent_ended_zero_size_event_count{id="2",name="Office"} 0.0
+zm_monitor_recent_ended_zero_size_event_count{id="3",name="DiningRoom"} 0.0
+zm_monitor_recent_ended_zero_size_event_count{id="4",name="LivingRoom"} 0.0
+zm_monitor_recent_ended_zero_size_event_count{id="5",name="BasementDoorRm"} 0.0
+zm_monitor_recent_ended_zero_size_event_count{id="6",name="Cats"} 0.0
+# HELP zm_monitor_recent_event_disk_space_bytes Sum of DiskSpace in bytes over events that ended in the last 900s -- recording throughput (windowed gauge, do not rate())
+# TYPE zm_monitor_recent_event_disk_space_bytes gauge
+zm_monitor_recent_event_disk_space_bytes{id="1",name="FrontPorch"} 1.185e+07
+zm_monitor_recent_event_disk_space_bytes{id="2",name="Office"} 2.14e+06
+zm_monitor_recent_event_disk_space_bytes{id="3",name="DiningRoom"} 2.431e+07
+zm_monitor_recent_event_disk_space_bytes{id="4",name="LivingRoom"} 3.42e+06
+zm_monitor_recent_event_disk_space_bytes{id="5",name="BasementDoorRm"} 3.512e+07
+zm_monitor_recent_event_disk_space_bytes{id="6",name="Cats"} 4.58e+06
+# HELP zm_monitor_recent_min_event_disk_space_bytes Smallest DiskSpace in bytes among events that ended in the last 900s -- surfaces partial/truncated writes (windowed gauge)
+# TYPE zm_monitor_recent_min_event_disk_space_bytes gauge
+zm_monitor_recent_min_event_disk_space_bytes{id="1",name="FrontPorch"} 3.87e+06
+zm_monitor_recent_min_event_disk_space_bytes{id="2",name="Office"} 2.14e+06
+zm_monitor_recent_min_event_disk_space_bytes{id="3",name="DiningRoom"} 4.12e+06
+zm_monitor_recent_min_event_disk_space_bytes{id="4",name="LivingRoom"} 1.63e+06
+zm_monitor_recent_min_event_disk_space_bytes{id="5",name="BasementDoorRm"} 3.98e+06
+zm_monitor_recent_min_event_disk_space_bytes{id="6",name="Cats"} 2.29e+06
+# HELP zm_monitor_recent_min_event_frames Smallest frame count among events that ended in the last 900s -- surfaces truncated events (windowed gauge)
+# TYPE zm_monitor_recent_min_event_frames gauge
+zm_monitor_recent_min_event_frames{id="1",name="FrontPorch"} 121.0
+zm_monitor_recent_min_event_frames{id="2",name="Office"} 101.0
+zm_monitor_recent_min_event_frames{id="3",name="DiningRoom"} 130.0
+zm_monitor_recent_min_event_frames{id="4",name="LivingRoom"} 95.0
+zm_monitor_recent_min_event_frames{id="5",name="BasementDoorRm"} 151.0
+zm_monitor_recent_min_event_frames{id="6",name="Cats"} 76.0
 # HELP zm_state Monitor state
 # TYPE zm_state gauge
 zm_state{definition="None",id="1",name="default"} 1.0

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ import logging
 import socket
 import time
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Generator, List, Dict, Optional, Tuple, Any
 import json
 
@@ -141,6 +141,114 @@ class InvalidStatusStringException(Exception):
 StatusType = Tuple[str, float, int]
 
 
+def _parse_zm_datetime(value: Optional[str]) -> Optional[datetime]:
+    """Parse a ZoneMinder events-API datetime string ('YYYY-MM-DD HH:MM:SS')
+    into a UTC-aware ``datetime``, or ``None`` if unset/unparseable.
+
+    The ZoneMinder API serializes event StartDateTime/EndDateTime in **UTC**,
+    regardless of the server's local timezone. We therefore attach UTC tzinfo
+    and callers must compare against ``datetime.now(timezone.utc)`` -- comparing
+    against a naive local ``datetime.now()`` would be wrong by the local UTC
+    offset (e.g. events appearing hours in the future). Note this differs from
+    :meth:`ZmExporter._parse_zmdc_status`, whose daemon-status strings are in
+    local time.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.strptime(
+            value, '%Y-%m-%d %H:%M:%S'
+        ).replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def _event_int(raw: Dict[str, Any], key: str) -> int:
+    """Return ``raw[key]`` as an int, treating None/''/unparseable as 0.
+
+    ZM's JSON returns numeric fields (DiskSpace, Frames, Emptied) as strings,
+    and DiskSpace is None/'' for events whose size ZM has not computed yet.
+    """
+    val = raw.get(key)
+    if val in (None, ''):
+        return 0
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return 0
+
+
+def aggregate_events(
+    raw_events: List[Dict[str, Any]],
+    monitor_ids: List[int],
+    now: datetime,
+    window_seconds: int,
+    grace_seconds: int,
+) -> Dict[int, Dict[str, Any]]:
+    """Aggregate raw ZM event dicts (``Event.get()`` output) into per-monitor
+    recording-persistence facts. Pure function -- no I/O -- so it is unit
+    testable without a live ZoneMinder.
+
+    For each monitor this computes:
+
+    * ``last_event`` -- the newest *ended* event ``(id, end_dt, disk, frames)``,
+      used as a freshness gate (a monitor that has not produced a completed
+      event recently simply has no ``last_event``).
+    * windowed aggregates over events that ended between ``grace_seconds`` and
+      ``window_seconds`` ago, excluding still-open events (no ``EndDateTime``)
+      and purged events (``Emptied=1``, whose files are legitimately gone):
+      ``ended_count``, ``zero_size_count``, ``disk_space_sum``,
+      ``min_disk_space``, ``min_frames``.
+
+    Windowed counters default to 0 for every id in ``monitor_ids`` so callers
+    can emit a series for every monitor even when it had no recent events.
+    """
+    def _blank() -> Dict[str, Any]:
+        return {
+            'ended_count': 0,
+            'zero_size_count': 0,
+            'disk_space_sum': 0,
+            'min_disk_space': None,
+            'min_frames': None,
+            'last_event': None,
+        }
+
+    agg: Dict[int, Dict[str, Any]] = {mid: _blank() for mid in monitor_ids}
+
+    for raw in raw_events:
+        try:
+            mid = int(raw['MonitorId'])
+            eid = int(raw['Id'])
+        except (KeyError, ValueError, TypeError):
+            continue
+        end_dt = _parse_zm_datetime(raw.get('EndDateTime'))
+        if end_dt is None:
+            # still-open / in-progress event: no final size yet -> ignore
+            continue
+        m = agg.setdefault(mid, _blank())
+        disk = _event_int(raw, 'DiskSpace')
+        frames = _event_int(raw, 'Frames')
+        # newest ended event by id, regardless of window -> freshness gate
+        prev = m['last_event']
+        if prev is None or eid > prev[0]:
+            m['last_event'] = (eid, end_dt, disk, frames)
+        # windowed aggregates: ended in [grace, window] ago, not purged
+        end_age = (now - end_dt).total_seconds()
+        if not (grace_seconds <= end_age <= window_seconds):
+            continue
+        if _event_int(raw, 'Emptied') == 1:
+            continue
+        m['ended_count'] += 1
+        m['disk_space_sum'] += disk
+        if disk == 0:
+            m['zero_size_count'] += 1
+        if m['min_disk_space'] is None or disk < m['min_disk_space']:
+            m['min_disk_space'] = disk
+        if m['min_frames'] is None or frames < m['min_frames']:
+            m['min_frames'] = frames
+    return agg
+
+
 class ZmExporter:
 
     STATUS_RE: re.Pattern = re.compile(
@@ -181,12 +289,29 @@ class ZmExporter:
         logger.debug('Connected to ZM')
         self.query_time: float = 0.0
         self._monitor_id_to_name: Dict[int, str] = {}
+        # Recording-persistence event metrics: aggregate over events that ended
+        # in the last ZM_EVENT_WINDOW_SECONDS (default 15m), ignoring the most
+        # recent ZM_EVENT_GRACE_SECONDS (default 2m) so events whose DiskSpace
+        # ZM has not finished computing yet do not read as zero-size failures.
+        # ZM_EVENT_QUERY_LIMIT bounds how many events a single scrape fetches;
+        # keep it comfortably above the busiest window so results are not
+        # truncated (pyzm sorts newest-first and stops at the limit).
+        self._event_window_seconds: int = int(
+            os.environ.get('ZM_EVENT_WINDOW_SECONDS', '900')
+        )
+        self._event_grace_seconds: int = int(
+            os.environ.get('ZM_EVENT_GRACE_SECONDS', '120')
+        )
+        self._event_query_limit: int = int(
+            os.environ.get('ZM_EVENT_QUERY_LIMIT', '500')
+        )
 
     def collect(self) -> Generator[Metric, None, None]:
         logger.debug('Beginning collection')
         qstart = time.time()
         for meth in [
             self._do_monitors,
+            self._do_events,
             self._do_states,
             self._do_monitor_shm,
             self._do_zmes_websocket,
@@ -534,6 +659,114 @@ class ZmExporter:
             archived_event_count, archived_event_disk_space, zmc, zmc_pid
         ]
         yield from int_metrics.values()
+
+    def _do_events(self) -> Generator[Metric, None, None]:
+        """Recording-persistence metrics derived from recently-ended events.
+
+        Every existing monitor metric proves *capture* is alive; these prove
+        events actually reached *disk*. Queries events over a window slightly
+        wider than ``ZM_EVENT_WINDOW_SECONDS`` (ZM filters by start time, so we
+        pad to still catch long events that ended inside the window), then
+        aggregates per monitor via :func:`aggregate_events`.
+        """
+        window: int = self._event_window_seconds
+        grace: int = self._event_grace_seconds
+        # pad the query back beyond the window (ZM filters by StartTime; +15m
+        # covers ZM's default max event section length so long events that
+        # ended inside the window are still returned).
+        query_minutes: int = (window // 60) + 15
+        options: Dict[str, Any] = {
+            'from': f'{query_minutes} minutes ago',
+            'limit': self._event_query_limit,
+        }
+        logger.debug('Querying events with options: %s', options)
+        try:
+            raw_events: List[Dict[str, Any]] = [
+                e.get() for e in self._api.events(options=options).list()
+            ]
+        except Exception as ex:
+            logger.error('Error querying events: %s', ex, exc_info=True)
+            return
+        logger.debug('Fetched %d events for window', len(raw_events))
+        # ZM's events API returns event datetimes in UTC (see
+        # _parse_zm_datetime), so compare against a UTC-aware now.
+        now: datetime = datetime.now(timezone.utc)
+        agg: Dict[int, Dict[str, Any]] = aggregate_events(
+            raw_events, list(self._monitor_id_to_name.keys()),
+            now, window, grace
+        )
+
+        last_disk = LabeledGaugeMetricFamily(
+            'zm_monitor_last_event_disk_space_bytes',
+            'DiskSpace in bytes of the most recent ended event for this monitor'
+        )
+        last_age = LabeledGaugeMetricFamily(
+            'zm_monitor_last_event_end_time_age_seconds',
+            'Seconds since the most recent ended event for this monitor ended'
+        )
+        last_frames = LabeledGaugeMetricFamily(
+            'zm_monitor_last_event_frames',
+            'Frame count of the most recent ended event for this monitor'
+        )
+        last_id = LabeledGaugeMetricFamily(
+            'zm_monitor_last_event_id',
+            'Event ID of the most recent ended event for this monitor '
+            '(monotonic; safe to use with increase() as an event-creation rate)'
+        )
+        ended_count = LabeledGaugeMetricFamily(
+            'zm_monitor_recent_ended_event_count',
+            f'Count of events that ended in the last {window}s (excludes '
+            f'still-open and purged events; windowed gauge, do not rate())'
+        )
+        zero_count = LabeledGaugeMetricFamily(
+            'zm_monitor_recent_ended_zero_size_event_count',
+            f'Count of events that ended in the last {window}s having saved '
+            f'zero bytes to disk (windowed gauge, do not rate())'
+        )
+        disk_sum = LabeledGaugeMetricFamily(
+            'zm_monitor_recent_event_disk_space_bytes',
+            f'Sum of DiskSpace in bytes over events that ended in the last '
+            f'{window}s -- recording throughput (windowed gauge, do not rate())'
+        )
+        min_disk = LabeledGaugeMetricFamily(
+            'zm_monitor_recent_min_event_disk_space_bytes',
+            f'Smallest DiskSpace in bytes among events that ended in the last '
+            f'{window}s -- surfaces partial/truncated writes (windowed gauge)'
+        )
+        min_frames = LabeledGaugeMetricFamily(
+            'zm_monitor_recent_min_event_frames',
+            f'Smallest frame count among events that ended in the last '
+            f'{window}s -- surfaces truncated events (windowed gauge)'
+        )
+
+        for mid, name in sorted(self._monitor_id_to_name.items()):
+            m: Optional[Dict[str, Any]] = agg.get(mid)
+            if not m:
+                continue
+            labels: Dict[str, str] = {'id': str(mid), 'name': name}
+            # windowed metrics: always emit (0 default) so a series exists for
+            # every monitor and "count > 0" alerts have something to evaluate.
+            ended_count.add_metric(labels=labels, value=m['ended_count'])
+            zero_count.add_metric(labels=labels, value=m['zero_size_count'])
+            disk_sum.add_metric(labels=labels, value=m['disk_space_sum'])
+            if m['min_disk_space'] is not None:
+                min_disk.add_metric(labels=labels, value=m['min_disk_space'])
+            if m['min_frames'] is not None:
+                min_frames.add_metric(labels=labels, value=m['min_frames'])
+            # point metrics: only when there is a recent ended event, so a
+            # quiet camera (no events) does not emit a stale/false series.
+            if m['last_event'] is not None:
+                eid, end_dt, disk, frames = m['last_event']
+                last_disk.add_metric(labels=labels, value=disk)
+                last_age.add_metric(
+                    labels=labels, value=(now - end_dt).total_seconds()
+                )
+                last_frames.add_metric(labels=labels, value=frames)
+                last_id.add_metric(labels=labels, value=eid)
+        yield from [
+            last_disk, last_age, last_frames, last_id,
+            ended_count, zero_count, disk_sum, min_disk, min_frames,
+        ]
 
     def _do_monitor_shm(self) -> Generator[Metric, None, None]:
         int_fields: List[str] = [

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,136 @@
+"""Unit tests for the pure event-aggregation logic in main.aggregate_events.
+
+Run with: python -m unittest test_main
+"""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from main import aggregate_events, _parse_zm_datetime, _event_int
+
+# ZM's events API returns UTC; the exporter compares against a UTC-aware now.
+NOW = datetime(2026, 7, 12, 12, 0, 0, tzinfo=timezone.utc)
+WINDOW = 900   # 15m
+GRACE = 120    # 2m
+
+
+def _event(eid, mid, *, ended_ago=None, disk='1000', frames='30',
+           emptied='0', open_event=False):
+    """Build a raw ZM event dict (Event.get() shape). ``ended_ago`` is seconds
+    before NOW that the event ended; ``open_event`` leaves EndDateTime null."""
+    end = None if open_event else (
+        (NOW - timedelta(seconds=ended_ago)).strftime('%Y-%m-%d %H:%M:%S')
+    )
+    return {
+        'Id': str(eid),
+        'MonitorId': str(mid),
+        'StartDateTime': (NOW - timedelta(seconds=(ended_ago or 0) + 30)
+                          ).strftime('%Y-%m-%d %H:%M:%S'),
+        'EndDateTime': end,
+        'DiskSpace': disk,
+        'Frames': frames,
+        'Emptied': emptied,
+    }
+
+
+class TestParsingHelpers(unittest.TestCase):
+
+    def test_parse_datetime(self):
+        self.assertEqual(
+            _parse_zm_datetime('2026-07-12 11:59:00'),
+            datetime(2026, 7, 12, 11, 59, 0, tzinfo=timezone.utc),
+        )
+        self.assertIsNone(_parse_zm_datetime(None))
+        self.assertIsNone(_parse_zm_datetime(''))
+        self.assertIsNone(_parse_zm_datetime('not-a-date'))
+
+    def test_event_int(self):
+        self.assertEqual(_event_int({'DiskSpace': '4096'}, 'DiskSpace'), 4096)
+        self.assertEqual(_event_int({'DiskSpace': None}, 'DiskSpace'), 0)
+        self.assertEqual(_event_int({'DiskSpace': ''}, 'DiskSpace'), 0)
+        self.assertEqual(_event_int({}, 'DiskSpace'), 0)
+        self.assertEqual(_event_int({'DiskSpace': 'x'}, 'DiskSpace'), 0)
+
+
+class TestAggregateEvents(unittest.TestCase):
+
+    def test_no_events_defaults_to_zero_series(self):
+        agg = aggregate_events([], [1, 2], NOW, WINDOW, GRACE)
+        self.assertEqual(set(agg), {1, 2})
+        for mid in (1, 2):
+            self.assertEqual(agg[mid]['ended_count'], 0)
+            self.assertEqual(agg[mid]['zero_size_count'], 0)
+            self.assertEqual(agg[mid]['disk_space_sum'], 0)
+            self.assertIsNone(agg[mid]['last_event'])
+            self.assertIsNone(agg[mid]['min_disk_space'])
+
+    def test_healthy_events(self):
+        events = [
+            _event(10, 1, ended_ago=300, disk='2000', frames='40'),
+            _event(11, 1, ended_ago=200, disk='3000', frames='50'),
+        ]
+        agg = aggregate_events(events, [1], NOW, WINDOW, GRACE)
+        m = agg[1]
+        self.assertEqual(m['ended_count'], 2)
+        self.assertEqual(m['zero_size_count'], 0)
+        self.assertEqual(m['disk_space_sum'], 5000)
+        self.assertEqual(m['min_disk_space'], 2000)
+        self.assertEqual(m['min_frames'], 40)
+        # newest by id is 11
+        self.assertEqual(m['last_event'][0], 11)
+        self.assertEqual(m['last_event'][2], 3000)
+
+    def test_zero_size_event_counted(self):
+        events = [
+            _event(20, 1, ended_ago=300, disk='2000'),
+            _event(21, 1, ended_ago=250, disk='0'),      # failed write
+            _event(22, 1, ended_ago=240, disk=None),     # DiskSpace not set
+        ]
+        m = aggregate_events(events, [1], NOW, WINDOW, GRACE)[1]
+        self.assertEqual(m['ended_count'], 3)
+        self.assertEqual(m['zero_size_count'], 2)
+        self.assertEqual(m['min_disk_space'], 0)
+
+    def test_grace_excludes_freshly_ended(self):
+        # ended 60s ago (< grace 120s): DiskSpace may not be computed yet, so
+        # it must NOT be counted (would be a false zero-size positive).
+        events = [_event(30, 1, ended_ago=60, disk='0')]
+        m = aggregate_events(events, [1], NOW, WINDOW, GRACE)[1]
+        self.assertEqual(m['ended_count'], 0)
+        self.assertEqual(m['zero_size_count'], 0)
+        # still visible as the newest ended event (freshness gate)
+        self.assertEqual(m['last_event'][0], 30)
+
+    def test_window_excludes_old_events(self):
+        events = [_event(40, 1, ended_ago=WINDOW + 300, disk='0')]
+        m = aggregate_events(events, [1], NOW, WINDOW, GRACE)[1]
+        self.assertEqual(m['ended_count'], 0)
+        self.assertEqual(m['zero_size_count'], 0)
+
+    def test_purged_event_not_a_failure(self):
+        # Emptied=1: files legitimately purged, must not count as zero-size.
+        events = [_event(50, 1, ended_ago=300, disk='0', emptied='1')]
+        m = aggregate_events(events, [1], NOW, WINDOW, GRACE)[1]
+        self.assertEqual(m['ended_count'], 0)
+        self.assertEqual(m['zero_size_count'], 0)
+
+    def test_open_event_ignored(self):
+        events = [
+            _event(60, 1, open_event=True),                 # recording now
+            _event(61, 1, ended_ago=300, disk='1500'),
+        ]
+        m = aggregate_events(events, [1], NOW, WINDOW, GRACE)[1]
+        self.assertEqual(m['ended_count'], 1)
+        # newest *ended* event is 61, not the open 60
+        self.assertEqual(m['last_event'][0], 61)
+
+    def test_unknown_monitor_gets_entry(self):
+        # event for a monitor not in the provided id list still aggregates
+        events = [_event(70, 9, ended_ago=300, disk='0')]
+        agg = aggregate_events(events, [1], NOW, WINDOW, GRACE)
+        self.assertIn(9, agg)
+        self.assertEqual(agg[9]['zero_size_count'], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Why

Every existing `zm_monitor_*` metric proves **capture** is alive (daemon up, grabbing frames into the mmap buffer). None prove that events actually reach **disk**. A failure where capture keeps working but writes fail — e.g. an unwritable/detached storage volume — leaves every capture metric green while nothing is recorded. This adds metrics that measure persistence.

## What

A new `_do_events()` collector queries recently-ended events over a configurable window and emits per-monitor persistence metrics:

- `zm_monitor_last_event_disk_space_bytes` / `_end_time_age_seconds` / `_frames` / `_id` — newest ended event (freshness-gated point signal; the `_id` is monotonic and safe for `increase()`)
- `zm_monitor_recent_ended_event_count`
- `zm_monitor_recent_ended_zero_size_event_count` — events that ended saving zero bytes
- `zm_monitor_recent_event_disk_space_bytes` — recording throughput (sum)
- `zm_monitor_recent_min_event_disk_space_bytes` / `_min_event_frames` — surface partial/truncated writes

## Correctness details

- Windowed aggregates exclude still-open events and purged (`Emptied=1`) events.
- A grace period excludes freshly-ended events whose `DiskSpace` ZM hasn't computed yet, so they don't read as false zero-size failures.
- **The ZM events API returns datetimes in UTC** — they're parsed UTC-aware and compared against `datetime.now(timezone.utc)`. Comparing against naive local `now` placed events hours in the future and silently excluded every event from the window (caught by running the collector against a live instance before merge).
- The `recent_*` metrics are sliding-window gauges — documented as "do not `rate()`".

## Config

`ZM_EVENT_WINDOW_SECONDS` (default 900), `ZM_EVENT_GRACE_SECONDS` (default 120), `ZM_EVENT_QUERY_LIMIT` (default 500, keeps the newest-first query from truncating the window).

## Tests

Aggregation logic is a pure function (`aggregate_events`) with 10 `unittest` cases covering grace exclusion, purged/open events, zero-size detection, newest-ended selection, and window bounds. README "Metrics Exposed" section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)